### PR TITLE
Initial PoC version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 Giant Swarm GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Roman Sokolkov <roman@giantswarm.io> (@r7vme) pkg:*

--- a/controller.go
+++ b/controller.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2017 Giant Swarm.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/tools/clientcmd"
+	nodeutilv1 "k8s.io/kubernetes/pkg/api/v1/node"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+
+	_ "github.com/giantswarm/kvm-operator-node-controller/provider"
+)
+
+const (
+	// nodeStatusUpdateRetry controls the number of retries of writing NodeStatus update.
+	nodeStatusUpdateRetry = 5
+
+	// The amount of time the nodecontroller should sleep between retrying NodeStatus updates
+	retrySleepTime = 20 * time.Millisecond
+
+	// The amount of time  between node status checks
+	nodeMonitorPeriod = 30 * time.Second
+)
+
+// Common variables.
+var (
+	description = "Calico node controller for Kubernetes."
+	gitCommit   = "n/a"
+	name        = "calico-node-controller"
+	source      = "https://github.com/giantswarm/calico-node-controller"
+)
+
+type controller struct {
+	kubeClient        clientset.Interface
+	cloud             cloudprovider.Interface
+	nodeMonitorPeriod time.Duration
+}
+
+func main() {
+	// Print version.
+	if (len(os.Args) > 1) && (os.Args[1] == "version") {
+		fmt.Printf("Description:    %s\n", description)
+		fmt.Printf("Git Commit:     %s\n", gitCommit)
+		fmt.Printf("Go Version:     %s\n", runtime.Version())
+		fmt.Printf("Name:           %s\n", name)
+		fmt.Printf("OS / Arch:      %s / %s\n", runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("Source:         %s\n", source)
+		return
+	}
+
+	var kubeconfig string
+	var master string
+	var help bool
+
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+	flag.StringVar(&master, "master", "", "master url")
+	flag.BoolVar(&help, "help", false, "Print usage and exit")
+	flag.Parse()
+
+	// Print usage.
+	if help {
+		flag.Usage()
+		return
+	}
+
+	// Create kubeclient config.
+	config, err := clientcmd.BuildConfigFromFlags(master, kubeconfig)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	// Create the client.
+	kubeClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	// Initialize kubernetes provider.
+	cloud, err := cloudprovider.InitCloudProvider("kubernetes", "")
+	if err != nil {
+		glog.Fatalf("failed to initialize cloud provider: %v", err)
+	}
+
+	// Create controller instance.
+	controller := newController(kubeClient, cloud, nodeMonitorPeriod)
+
+	// Start the kvm-operator node controller.
+	stop := make(chan struct{})
+	defer close(stop)
+	go controller.Run(stop)
+
+	// Wait forever.
+	select {}
+}
+
+// Creates new instance of controller.
+func newController(
+	kubeClient clientset.Interface,
+	cloud cloudprovider.Interface,
+	nodeMonitorPeriod time.Duration) *controller {
+	return &controller{
+		kubeClient:        kubeClient,
+		cloud:             cloud,
+		nodeMonitorPeriod: nodeMonitorPeriod,
+	}
+}
+
+// Run controller function in a loop.
+func (c *controller) Run(stopCh chan struct{}) {
+	defer utilruntime.HandleCrash()
+
+	// Let the workers stop when we are done
+	glog.Info("Starting kvm-operator node controller")
+
+	// Start a loop to periodically check if any nodes have been deleted from cloudprovider
+	go wait.Until(c.MonitorNode, c.nodeMonitorPeriod, stopCh)
+
+	<-stopCh
+	glog.Info("Stopping kvm-operator node controller")
+}
+
+// Monitor node queries the cloudprovider for non-ready nodes and deletes them
+// if they cannot be found in the cloud provider.
+func (c *controller) MonitorNode() {
+	// Get nodes from cloud provider.
+	instances, ok := c.cloud.Instances()
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("failed to get instances from cloud provider"))
+		return
+	}
+
+	// Get nodes known by kubernetes cluster.
+	nodes, err := c.kubeClient.CoreV1().Nodes().List(metav1.ListOptions{ResourceVersion: "0"})
+	if err != nil {
+		glog.Errorf("Error monitoring node status: %v", err)
+		return
+	}
+
+	for i := range nodes.Items {
+		var currentReadyCondition *v1.NodeCondition
+		node := &nodes.Items[i]
+
+		glog.Infof("Checking node %s", node.Name)
+
+		// Try to get the current node status
+		// If node status is empty, then kubelet has not posted ready status yet. In this case,
+		// try nodeStatusUpdateRetry times. If still nothing than give up this node and process next node.
+		for rep := 0; rep < nodeStatusUpdateRetry; rep++ {
+			_, currentReadyCondition = nodeutilv1.GetNodeCondition(&node.Status, v1.NodeReady)
+			if currentReadyCondition != nil {
+				break
+			}
+			name := node.Name
+			node, err = c.kubeClient.CoreV1().Nodes().Get(name, metav1.GetOptions{})
+			if err != nil {
+				glog.Errorf("Failed while getting a Node to retry updating NodeStatus. Probably Node %s was deleted.", name)
+				break
+			}
+			time.Sleep(retrySleepTime)
+		}
+		if currentReadyCondition == nil {
+			glog.Errorf("Update status of Node %v from Controller exceeds retry count or the Node was deleted.", node.Name)
+			continue
+		}
+		// If the known node status says that Node is NotReady, then check if the node has been removed
+		// from the cloud provider. If node cannot be found in cloudprovider, then delete the node immediately.
+		if currentReadyCondition != nil {
+			if currentReadyCondition.Status != v1.ConditionTrue {
+				// Check with the cloud provider to see if the node still exists. If it
+				// doesn't, delete the node immediately.
+				exists, err := ensureNodeExists(instances, node)
+				if err != nil {
+					glog.Errorf("Error getting data for node %s from cloud provider: %v", node.Name, err)
+					continue
+				}
+
+				if exists {
+					// Continue checking the remaining nodes since the current one is fine.
+					continue
+				}
+
+				glog.Infof("Deleting node since it is no longer present in cloud provider: %s", node.Name)
+
+				go func(nodeName string) {
+					defer utilruntime.HandleCrash()
+					if err := c.kubeClient.CoreV1().Nodes().Delete(nodeName, nil); err != nil {
+						glog.Errorf("unable to delete node %q: %v", nodeName, err)
+					}
+				}(node.Name)
+
+			}
+		}
+		glog.Infof("Node %s Ready state is %s.", node.Name, currentReadyCondition.Status)
+	}
+}
+
+// Checks if the instance exists in host cluster
+func ensureNodeExists(instances cloudprovider.Instances, node *v1.Node) (bool, error) {
+	_, err := instances.ExternalID(types.NodeName(node.Name))
+	if err != nil {
+		if err == cloudprovider.InstanceNotFound {
+			return false, nil
+		}
+		return false, fmt.Errorf("ensureNodeExists: Error fetching by NodeName: %v", err)
+	}
+
+	return true, nil
+}

--- a/controller_test.go
+++ b/controller_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2017 Giant Swarm.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+	fakecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
+	"k8s.io/kubernetes/pkg/controller/testutil"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// This test checks that the node is deleted when kubelet stops reporting
+// and cloud provider says node is gone
+func TestNodeDeleted(t *testing.T) {
+	pod0 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod0",
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node0",
+		},
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodReady,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	pod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod1",
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node0",
+		},
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodReady,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	fnh := &testutil.FakeNodeHandler{
+		Existing: []*v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionUnknown,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+		},
+		Clientset:      fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*pod0, *pod1}}),
+		DeleteWaitChan: make(chan struct{}),
+	}
+
+	controller := &controller{
+		kubeClient: fnh,
+		cloud: &fakecloud.FakeCloud{
+			ExtID: map[types.NodeName]string{
+				types.NodeName("node0"): "node0",
+			},
+			Err: cloudprovider.InstanceNotFound,
+		},
+		nodeMonitorPeriod: 1 * time.Second,
+	}
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go controller.Run(stop)
+
+	select {
+	case <-fnh.DeleteWaitChan:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Errorf("Timed out waiting %v for node to be deleted", wait.ForeverTestTimeout)
+	}
+
+	assert.Equal(t, 1, len(fnh.DeletedNodes), "Node was not deleted")
+	assert.Equal(t, "node0", fnh.DeletedNodes[0].Name, "Node was not deleted")
+}

--- a/provider/cloud.go
+++ b/provider/cloud.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2017 Giant Swarm.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"io"
+	"os"
+
+	"github.com/golang/glog"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/controller"
+)
+
+const providerName string = "kubernetes"
+const providerKubeconfigEnv string = "PROVIDER_HOST_CLUSTER_KUBECONFIG"
+const providerNamespaceEnv string = "PROVIDER_HOST_CLUSTER_NAMESPACE"
+
+type cloud struct {
+	client    clientset.Interface
+	instances cloudprovider.Instances
+}
+
+func newCloud(config io.Reader) (cloudprovider.Interface, error) {
+	// Check if namespace is set.
+	namespace := os.Getenv(providerNamespaceEnv)
+	if namespace == "" {
+		glog.Fatalf("Error: Please specify host cluster namespace via %s.\n", providerNamespaceEnv)
+	}
+
+	// Get kubeconfig for host cluster.
+	// This is not required as we are running in host cluster
+	// so by default in-cluster configuration will be used.
+	kubeconfig := os.Getenv(providerKubeconfigEnv)
+	if kubeconfig == "" {
+		glog.Infof("%s is not set. Will try to use in-cluster config.\n", providerKubeconfigEnv)
+	}
+
+	// Create kubeclient config.
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	// Create the client.
+	hostClient, err := clientset.NewForConfig(cfg)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	return &cloud{
+		client:    hostClient,
+		instances: newInstances(hostClient, namespace),
+	}, nil
+}
+
+func init() {
+	cloudprovider.RegisterCloudProvider(providerName, func(config io.Reader) (cloudprovider.Interface, error) {
+		return newCloud(config)
+	})
+}
+
+func (c *cloud) Initialize(clientBuilder controller.ControllerClientBuilder) {
+}
+
+func (c *cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	return nil, false
+}
+
+func (c *cloud) Instances() (cloudprovider.Instances, bool) {
+	return c.instances, true
+}
+
+func (c *cloud) Zones() (cloudprovider.Zones, bool) {
+	return nil, false
+}
+
+func (c *cloud) Clusters() (cloudprovider.Clusters, bool) {
+	return nil, false
+}
+
+func (c *cloud) Routes() (cloudprovider.Routes, bool) {
+	return nil, false
+}
+
+func (c *cloud) ProviderName() string {
+	return providerName
+}
+
+func (c *cloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nil, nil
+}
+
+func (c *cloud) HasClusterID() bool {
+	return false
+}

--- a/provider/instances.go
+++ b/provider/instances.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2017 Giant Swarm.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"errors"
+
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	podutilv1 "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+type instances struct {
+	client    clientset.Interface
+	namespace string
+}
+
+func newInstances(client clientset.Interface, namespace string) cloudprovider.Instances {
+	return &instances{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+func (i *instances) AddSSHKeyToAllInstances(user string, keyData []byte) error {
+	return errors.New("not implemented")
+}
+
+// ExternalID returns the pod name of the VM in host cluster.
+// If the pod does not exist or not ready, the
+// returned error will be cloudprovider.InstanceNotFound.
+func (i *instances) ExternalID(nodeName types.NodeName) (string, error) {
+	// Try to get requested pod in namespace.
+	glog.Infof("Checking pod %s in namespace %s.", string(nodeName), i.namespace)
+	pod, err := i.client.CoreV1().Pods(i.namespace).Get(string(nodeName), metav1.GetOptions{})
+
+	if apierr.IsNotFound(err) {
+		// Handle not found error.
+		glog.Infof("Pod %s not found in namespace %s.", string(nodeName), i.namespace)
+		return "", cloudprovider.InstanceNotFound
+	} else if err != nil {
+		// Handle other errors.
+		glog.Errorf("Error getting pod %s: %v.", string(nodeName), err)
+		return "", err
+	} else if !podutilv1.IsPodReady(pod) {
+		// Check if pod is not ready. e.g. if pod stuck in Terminating state or CrashLoopBackoff.
+		glog.Infof("Pod %s in namespace %s is not ready.\n", string(nodeName), i.namespace)
+		return "", cloudprovider.InstanceNotFound
+	}
+
+	// Finally if none of conditions above are met return that pod is OK.
+	glog.Infof("Pod %s in namespace %s is ready.\n", string(nodeName), i.namespace)
+	return string(nodeName), nil
+}
+
+func (i *instances) CurrentNodeName(hostname string) (types.NodeName, error) {
+	return types.NodeName(""), errors.New("not implemented")
+}
+
+func (i *instances) InstanceID(nodeName types.NodeName) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (i *instances) InstanceType(name types.NodeName) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (i *instances) InstanceTypeByProviderID(providerID string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (i *instances) InstanceExistsByProviderID(providerID string) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (i *instances) NodeAddresses(name types.NodeName) ([]v1.NodeAddress, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (i *instances) NodeAddressesByProviderID(providerID string) ([]v1.NodeAddress, error) {
+	return nil, errors.New("not implemented")
+}


### PR DESCRIPTION
This controller runs in host cluster as a pod.

It does 3 things:
1) Check guest cluster for NotReady node
2) Check correspondong pod in host cluster
3) Delete NotReady node if no pod host cluster

This is working version that was tested.

Regarding architecture:

Controller and provider implemented like "out-of-tree" kubernetes
cloud controller manager. See about cloud-controller-manager [1].
I would love to keep controller and provider as close as possible to
Kubernetes recommendations. In the future this potentially can become
external cloud provider (e.g. create Load Balancers/Persistent volumes).

1 - https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller

Part of:
giantswarm/k8scloudconfig#162
giantswarm/giantswarm#1830